### PR TITLE
fix: update broken tests to better adhear to NIST

### DIFF
--- a/nist80022.go
+++ b/nist80022.go
@@ -93,39 +93,8 @@ func getBlock(s string, startIndex int) string {
 	return s[startIndex : startIndex+len(s)]
 }
 
-// toBlock converts an integer to a binary string of size bits
-func toBlock(num int, size int) string {
-	if size == 0 {
-		return ""
-	}
-	if num%2 == 0 {
-		return toBlock(num/2, size-1) + "0"
-	}
-	return toBlock(num/2, size-1) + "1"
-}
-
-// toIndex converts a binary string to an integer
-func toIndex(bit string) int {
-	if bit == "" {
-		return 0
-	}
-	n := len(bit)
-	if n > 31 {
-		return 0
-	}
-	var index int
-	for i := 0; i < n; i++ {
-		if bit[i] != '0' && bit[i] != '1' {
-			return 0
-		}
-		index = (index << 1) | int(bit[i]-'0')
-	}
-	return index
-}
-
 type BitArray struct {
 	data []byte
-	size int
 }
 
 func NewBitArray(size int) *BitArray {

--- a/nist80022.go
+++ b/nist80022.go
@@ -93,40 +93,47 @@ func getBlock(s string, startIndex int) string {
 	return s[startIndex : startIndex+len(s)]
 }
 
+// BitArray is a structure representing an array of bits.
 type BitArray struct {
-	data []byte
+	data []byte // data holds the actual bytes storing the bits.
 }
 
+// NewBitArray initializes and returns a new BitArray of the specified size.
 func NewBitArray(size int) *BitArray {
 	return &BitArray{
-		data: make([]byte, (size+7)>>3),
+		data: make([]byte, (size+7)>>3), // Allocate the byte array, taking into account the size of a byte (8 bits).
 	}
 }
 
+// Set modifies the value of the bit at the specified index to the given value (true or false).
 func (b *BitArray) Set(index int, value bool) {
 	if value {
-		b.data[index>>3] |= 1 << (index & 7)
+		b.data[index>>3] |= 1 << (index & 7) // Set the bit to 1.
 	} else {
-		b.data[index>>3] &^= 1 << (index & 7)
+		b.data[index>>3] &^= 1 << (index & 7) // Set the bit to 0.
 	}
 }
 
+// Get retrieves the boolean value of the bit at the specified index.
 func (b *BitArray) Get(index int) bool {
-	return (b.data[index>>3] & (1 << (index & 7))) != 0
+	return (b.data[index>>3] & (1 << (index & 7))) != 0 // Extract the bit value and convert it to a boolean.
 }
 
+// Size returns the total number of bits in the BitArray.
 func (b *BitArray) Size() int {
-	return len(b.data) << 3
+	return len(b.data) << 3 // Calculate the number of bits by multiplying the length of the byte array by 8.
 }
 
+// IntArrayToBitArray converts an array of integers into a BitArray.
 func IntArrayToBitArray(intArray []int) *BitArray {
-	n := len(intArray) * 8
-	bitArray := NewBitArray(n)
+	n := len(intArray) * 8     // Calculate the total number of bits required to store the integers.
+	bitArray := NewBitArray(n) // Create a new BitArray of the required size.
 
+	// Iterate through the integers and set their bits in the BitArray.
 	for i, value := range intArray {
 		for j := 0; j < 8; j++ {
-			bit := (value >> (7 - j)) & 1
-			bitArray.Set(i*8+j, bit == 1)
+			bit := (value >> (7 - j)) & 1 // Extract the individual bits from the integer.
+			bitArray.Set(i*8+j, bit == 1) // Set the corresponding bit in the BitArray.
 		}
 	}
 

--- a/nist80022.go
+++ b/nist80022.go
@@ -175,13 +175,6 @@ func matrixRank(matrix [][]int, size int) int {
 	return rank
 }
 
-func boolToInt(value bool) int {
-	if value {
-		return 1
-	}
-	return 0
-}
-
 // BinaryMatrixRankTest performs the binary matrix rank test on the input
 // bit string. The test divides the bit string into m x q binary matrices,
 // and calculates the rank of each matrix. It then calculates the chi-squared
@@ -232,47 +225,6 @@ func BinaryMatrixRankTest(bitArray *BitArray, matrixSize int) (float64, bool) {
 	alpha := 0.001
 	pass := pValue > alpha
 	return pValue, pass
-}
-
-// calculateMatrixRank computes the rank of a binary matrix using Gaussian
-// elimination with partial pivoting.
-//
-// matrix: the binary matrix to calculate the rank of.
-// m: the number of rows in the matrix.
-// q: the number of columns in the matrix.
-func calculateMatrixRank(matrix [][]int, m, q int) int {
-	rank := 0
-	for j := 0; j < q; j++ {
-		// Find the row with the largest absolute value in column j
-		maxRowIndex := j
-		for i := j + 1; i < m; i++ {
-			if math.Abs(float64(matrix[i][j])) > math.Abs(float64(matrix[maxRowIndex][j])) {
-				maxRowIndex = i
-			}
-		}
-
-		// Swap rows to put the maximum element at position (j,j)
-		if maxRowIndex != j {
-			matrix[j], matrix[maxRowIndex] = matrix[maxRowIndex], matrix[j]
-		}
-
-		// Check if the element at position (j,j) is non-zero
-		if matrix[j][j] == 0 {
-			continue
-		}
-
-		// Zero out all elements in column j below the diagonal element
-		for i := j + 1; i < m; i++ {
-			if matrix[i][j] != 0 {
-				for k := j + 1; k < q; k++ {
-					matrix[i][k] = (matrix[i][k] + matrix[j][k]) % 2
-				}
-			}
-		}
-
-		rank++
-	}
-	return rank
 }
 
 // CumulativeSumsTest or the NIST cumulative sums test is a statistical test to determine if the number of ones and zeros in a binary sequence are evenly distributed.


### PR DESCRIPTION
## Fixes

- Fixes: LongestRunOfOnes, ApproximateEntropy, Runs, and CumulativeSums. This code more closely aligns with the NIST paper with NIST's C++ implementations as a guide.

## Proposed Changes

- Change

---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
